### PR TITLE
Simplify CTA buttons to arrow links

### DIFF
--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -4,8 +4,23 @@ function QA({q, a}:{q:string; a:string}) {
   const [open, setOpen] = useState(false);
   return (
     <div className="reveal border border-slate-200 bg-white rounded-xl mb-3 overflow-hidden shadow-sm">
-      <button onClick={()=>setOpen(!open)} className="w-full text-left px-6 py-4 font-bold flex items-center justify-between hover:bg-slate-50 transition-colors">
-        {q} <span className={`transition-transform ${open ? 'rotate-45' : ''}`}>+</span>
+      <button
+        onClick={()=>setOpen(!open)}
+        className="w-full text-left px-6 py-4 font-bold flex items-center justify-between hover:bg-slate-50 transition-colors"
+      >
+        {q}
+        <svg
+          className={`w-4 h-4 transition-transform ${open ? 'rotate-90' : ''}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M9 5l7 7-7 7" />
+        </svg>
       </button>
       <div className={`px-6 overflow-hidden transition-[max-height] duration-300 ${open ? 'max-h-60 pb-4' : 'max-h-0'}`}>
         <p className="text-slate-700">{a}</p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -11,8 +11,44 @@ export default function Hero() {
             Reliable water cart delivery and earthmoving across South Australia.
           </p>
           <div className="mt-8 flex gap-4">
-            <a href="#quote" className="bg-[#00B4D8] text-[#0B1F2A] font-extrabold px-6 py-3 rounded-xl hover:bg-[#00A3C4] transition-colors">Request a Quote</a>
-            <a href="#contact" className="border-2 border-[#00B4D8] text-[#00B4D8] px-6 py-3 rounded-xl hover:bg-[#00B4D8] hover:text-white transition-colors">Book Water</a>
+            <a
+              href="#quote"
+              className="flex items-center gap-2 text-[#00B4D8]"
+            >
+              Request a Quote
+              <svg
+                className="w-4 h-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14" />
+                <path d="M12 5l7 7-7 7" />
+              </svg>
+            </a>
+            <a
+              href="#contact"
+              className="flex items-center gap-2 text-[#00B4D8]"
+            >
+              Book Water
+              <svg
+                className="w-4 h-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14" />
+                <path d="M12 5l7 7-7 7" />
+              </svg>
+            </a>
           </div>
           <div className="mt-6 inline-flex items-center gap-3 rounded-xl border-8 border-[#00B4D8] bg-slate-50 px-4 py-3">
             <span className="text-[#00B4D8] font-extrabold bg-[#e0f7ff] rounded-full px-3 py-1 text-sm">Community</span>

--- a/src/components/Quote.tsx
+++ b/src/components/Quote.tsx
@@ -4,7 +4,10 @@ export default function Quote() {
       <div className="max-w-7xl mx-auto px-6 grid md:grid-cols-2 gap-8">
         <div className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-6">
           <h2 className="font-extrabold text-2xl mb-4" style={{fontFamily:'Montserrat'}}>Request a Quote</h2>
-          <form onSubmit={(e)=>{e.preventDefault(); alert('Demo — wire to email/form service in production');}} className="space-y-4">
+          <form
+            onSubmit={(e)=>{e.preventDefault(); alert('Demo — wire to email/form service in production');}}
+            className="flex flex-col space-y-4"
+          >
             <input required placeholder="Full Name" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
             <input required type="email" placeholder="Email" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
             <input required placeholder="Phone" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
@@ -18,13 +21,34 @@ export default function Quote() {
               <option>Other</option>
             </select>
             <textarea rows={4} placeholder="Tell us about your job…" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"></textarea>
-            <button className="bg-[#00B4D8] text-[#0B1F2A] font-extrabold px-6 py-3 rounded-lg w-full hover:bg-[#00A3C4] transition-colors">Send Request</button>
+            <button
+              type="submit"
+              aria-label="Send Request"
+              className="ml-auto inline-flex items-center text-[#00B4D8]"
+            >
+              <svg
+                className="w-5 h-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14" />
+                <path d="M12 5l7 7-7 7" />
+              </svg>
+            </button>
           </form>
         </div>
 
         <div className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-6" id="contact">
           <h2 className="font-extrabold text-2xl mb-4" style={{fontFamily:'Montserrat'}}>Book Water</h2>
-          <form onSubmit={(e)=>{e.preventDefault(); alert('Demo — wire to email/form service in production');}} className="space-y-4">
+          <form
+            onSubmit={(e)=>{e.preventDefault(); alert('Demo — wire to email/form service in production');}}
+            className="flex flex-col space-y-4"
+          >
             <input required placeholder="Name" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
             <input required placeholder="Phone" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
             <input type="email" placeholder="Email" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
@@ -36,7 +60,25 @@ export default function Quote() {
               </select>
               <input type="number" min="1" step="1" placeholder="Quantity (kL)" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
             </div>
-            <button className="bg-[#00B4D8] text-[#0B1F2A] font-extrabold px-6 py-3 rounded-lg w-full hover:bg-[#00A3C4] transition-colors">Book Delivery</button>
+            <button
+              type="submit"
+              aria-label="Book Delivery"
+              className="ml-auto inline-flex items-center text-[#00B4D8]"
+            >
+              <svg
+                className="w-5 h-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14" />
+                <path d="M12 5l7 7-7 7" />
+              </svg>
+            </button>
           </form>
         </div>
       </div>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -20,7 +20,25 @@ export default function Services() {
               <li>17,500 L trucks ready to go</li>
             </ul>
             <div className="mt-4">
-              <a href="#contact" className="border-2 border-[#00B4D8] text-[#00B4D8] font-extrabold px-4 py-2 rounded-lg text-sm hover:bg-[#00B4D8] hover:text-white transition-colors">Book Water</a>
+              <a
+                href="#contact"
+                className="group inline-flex items-center gap-2 text-[#00B4D8] hover:underline"
+              >
+                Book Water
+                <svg
+                  className="w-4 h-4 transition-transform group-hover:translate-x-1"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M5 12h14" />
+                  <path d="M12 5l7 7-7 7" />
+                </svg>
+              </a>
             </div>
           </Card>
           
@@ -32,7 +50,25 @@ export default function Services() {
               <li>Clean, safe worksites</li>
             </ul>
             <div className="mt-4">
-              <a href="#quote" className="border-2 border-[#00B4D8] text-[#00B4D8] font-extrabold px-4 py-2 rounded-lg text-sm hover:bg-[#00B4D8] hover:text-white transition-colors">Request Quote</a>
+              <a
+                href="#quote"
+                className="group inline-flex items-center gap-2 text-[#00B4D8] hover:underline"
+              >
+                Request Quote
+                <svg
+                  className="w-4 h-4 transition-transform group-hover:translate-x-1"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M5 12h14" />
+                  <path d="M12 5l7 7-7 7" />
+                </svg>
+              </a>
             </div>
           </Card>
           
@@ -44,7 +80,25 @@ export default function Services() {
               <li>Local SA crew</li>
             </ul>
             <div className="mt-4">
-              <a href="#contact" className="border-2 border-[#00B4D8] text-[#00B4D8] font-extrabold px-4 py-2 rounded-lg text-sm hover:bg-[#00B4D8] hover:text-white transition-colors">About us</a>
+              <a
+                href="#contact"
+                className="group inline-flex items-center gap-2 text-[#00B4D8] hover:underline"
+              >
+                About us
+                <svg
+                  className="w-4 h-4 transition-transform group-hover:translate-x-1"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M5 12h14" />
+                  <path d="M12 5l7 7-7 7" />
+                </svg>
+              </a>
             </div>
           </Card>
         </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -25,12 +25,25 @@ const Home = () => {
       <Footer />
       
       {/* Floating CTA */}
-      <button 
-        className="fixed right-6 bottom-6 z-50 bg-[#00B4D8] text-[#0B1F2A] font-extrabold px-4 py-3 rounded-xl shadow-lg hover:bg-[#00A3C4] transition-colors"
-        onClick={() => document.querySelector('#quote')?.scrollIntoView({behavior:'smooth'})}
+      <a
+        href="#quote"
+        className="fixed right-6 bottom-6 z-50 inline-flex items-center gap-2 text-[#00B4D8]"
       >
         Request a Quote
-      </button>
+        <svg
+          className="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M5 12h14" />
+          <path d="M12 5l7 7-7 7" />
+        </svg>
+      </a>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- convert hero and services CTAs to text links with arrow icons
- make quote form submissions and FAQ toggles arrow-based
- swap floating quote button for subtle corner link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b010ec4ecc832abdcf971f6d9b2fb6