### PR TITLE
Expand section spacing for clearer layout

### DIFF
--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -16,8 +16,8 @@ function QA({q, a}:{q:string; a:string}) {
 
 export default function FAQ() {
   return (
-    <section id="faq" className="py-16 bg-white">
-      <div className="max-w-3xl mx-auto px-6">
+    <section id="faq" className="py-32 bg-white">
+      <div className="max-w-3xl mx-auto px-10">
         <h2 className="reveal font-extrabold text-3xl mb-8 text-center" style={{fontFamily:'Montserrat'}}>FAQs</h2>
         <QA q="Do you deliver potable water?" a="Yes. We supply potable and non-potable water and can advise the best option for your job." />
         <QA q="How much can you deliver per load?" a="2,000 L trailers and 8,000 L / 13,000 L / 17,500 L trucks. Multiple loads can be scheduled for large fills." />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 export default function Footer() {
   return (
     <footer className="bg-white text-slate-700 mt-16 border-t border-slate-200">
-      <div className="max-w-7xl mx-auto px-6 py-12 grid md:grid-cols-3 gap-8">
+      <div className="max-w-7xl mx-auto px-10 py-24 grid md:grid-cols-3 gap-8">
         <div>
           <h3 className="text-slate-900 font-bold text-xl mb-3" style={{fontFamily:'Montserrat'}}>More Civil</h3>
           <p className="text-slate-600">Water cart delivery and civil earthworks across South Australia.</p>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -9,8 +9,8 @@ export default function Gallery() {
   const [src, setSrc] = useState<string | null>(null);
 
   return (
-    <section id="projects" className="py-16 bg-white">
-      <div className="max-w-7xl mx-auto px-6">
+    <section id="projects" className="py-32 bg-white">
+      <div className="max-w-7xl mx-auto px-10">
         <h2 className="reveal font-extrabold text-3xl mb-8 text-center" style={{fontFamily:'Montserrat'}}>Recent projects</h2>
       </div>
     </section>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,7 +1,7 @@
 export default function Hero() {
   return (
-    <section id="home" className="relative bg-white text-slate-900 overflow-hidden pt-28">
-      <div className="max-w-7xl mx-auto grid md:grid-cols-2 gap-10 items-center px-6 py-16">
+    <section id="home" className="relative bg-white text-slate-900 overflow-hidden pt-40">
+      <div className="max-w-7xl mx-auto grid md:grid-cols-2 gap-20 items-center px-10 py-32">
         <div className="reveal">
           <h1 className="font-extrabold leading-tight text-4xl md:text-5xl lg:text-6xl"
               style={{fontFamily:'Montserrat'}}>

--- a/src/components/Quote.tsx
+++ b/src/components/Quote.tsx
@@ -1,10 +1,10 @@
 export default function Quote() {
   return (
-    <section id="quote" className="py-16 bg-white">
-      <div className="max-w-7xl mx-auto px-6 grid md:grid-cols-2 gap-8">
-        <div className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-6">
+    <section id="quote" className="py-32 bg-white">
+      <div className="max-w-7xl mx-auto px-10 grid md:grid-cols-2 gap-8">
+        <div className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-10">
           <h2 className="font-extrabold text-2xl mb-4" style={{fontFamily:'Montserrat'}}>Request a Quote</h2>
-          <form onSubmit={(e)=>{e.preventDefault(); alert('Demo — wire to email/form service in production');}} className="space-y-4">
+          <form onSubmit={(e)=>{e.preventDefault(); alert('Demo — wire to email/form service in production');}} className="space-y-8">
             <input required placeholder="Full Name" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
             <input required type="email" placeholder="Email" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
             <input required placeholder="Phone" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
@@ -22,9 +22,9 @@ export default function Quote() {
           </form>
         </div>
 
-        <div className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-6" id="contact">
+        <div className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-10" id="contact">
           <h2 className="font-extrabold text-2xl mb-4" style={{fontFamily:'Montserrat'}}>Book Water</h2>
-          <form onSubmit={(e)=>{e.preventDefault(); alert('Demo — wire to email/form service in production');}} className="space-y-4">
+          <form onSubmit={(e)=>{e.preventDefault(); alert('Demo — wire to email/form service in production');}} className="space-y-8">
             <input required placeholder="Name" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
             <input required placeholder="Phone" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
             <input type="email" placeholder="Email" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,5 +1,5 @@
 const Card = ({badge, title, children}:{badge:string; title:string; children:React.ReactNode}) => (
-  <div className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-6">
+  <div className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-10">
     <span className="inline-block bg-[#e0f7ff] text-[#043b4a] px-3 py-1 rounded-full font-bold text-sm mb-3">{badge}</span>
     <h3 className="font-bold text-lg mb-3" style={{fontFamily:'Montserrat'}}>{title}</h3>
     <div className="[&>ul]:list-disc [&>ul]:pl-5 [&>p]:text-slate-700 [&>ul]:text-slate-700">{children}</div>
@@ -8,10 +8,10 @@ const Card = ({badge, title, children}:{badge:string; title:string; children:Rea
 
 export default function Services() {
   return (
-    <section id="services" className="py-16 bg-white">
-      <div className="max-w-7xl mx-auto px-6">
+    <section id="services" className="py-32 bg-white">
+      <div className="max-w-7xl mx-auto px-10">
         <h2 className="reveal font-extrabold text-3xl mb-8 text-center" style={{fontFamily:'Montserrat'}}>What we do</h2>
-        <div className="grid md:grid-cols-3 gap-6">
+        <div className="grid md:grid-cols-3 gap-12">
           <Card badge="Water Delivery" title="Potable & non-potable">
             <p>Bulk deliveries for tanks, pools, events, civil & roadworks.</p>
             <ul className="mt-3">


### PR DESCRIPTION
## Summary
- increase Hero padding and grid spacing for expanded top section
- double section spacing across Services, Gallery, FAQ, Quote, Footer
- enlarge internal gaps and card padding for more breathing room

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b010dca240832ab8102f6350000275