### PR TITLE
Use Montserrat font across site

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,7 @@ npm run preview # Must serve application successfully
 ### Styling Changes
 - Uses Tailwind CSS with custom design system
 - Brand colors: Blue (#00B4D8), Dark Blue (#0B1F2A)
-- Uses custom fonts: Inter (body), Montserrat (headings)
+- Uses custom font: Montserrat (site-wide)
 - Always test on different screen sizes
 
 ### CI/CD Integration

--- a/index.html
+++ b/index.html
@@ -7,12 +7,11 @@
     <meta name="description" content="Professional water and civil engineering services - Water delivery, civil construction, excavation and more." />
     <meta name="author" content="MORECIVIL" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=Montserrat:wght@700;800;900&display=swap" rel="stylesheet">
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=Montserrat:wght@700;800;900&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800;900&display=swap"
+      rel="stylesheet"
+    />
 
     <meta property="og:title" content="civil-aqua-flow" />
     <meta property="og:description" content="Lovable Generated Project" />

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -18,7 +18,7 @@ export default function FAQ() {
   return (
     <section id="faq" className="py-32 bg-white">
       <div className="max-w-3xl mx-auto px-10">
-        <h2 className="reveal font-extrabold text-3xl mb-8 text-center" style={{fontFamily:'Montserrat'}}>FAQs</h2>
+        <h2 className="reveal font-extrabold text-3xl mb-8 text-center">FAQs</h2>
         <QA q="Do you deliver potable water?" a="Yes. We supply potable and non-potable water and can advise the best option for your job." />
         <QA q="How much can you deliver per load?" a="2,000 L trailers and 8,000 L / 13,000 L / 17,500 L trucks. Multiple loads can be scheduled for large fills." />
         <QA q="Do you handle tight access?" a="Yes. Our operators plan access and safety on every job, including tight sites." />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,18 +3,18 @@ export default function Footer() {
     <footer className="bg-white text-slate-700 mt-16 border-t border-slate-200">
       <div className="max-w-7xl mx-auto px-10 py-24 grid md:grid-cols-3 gap-8">
         <div>
-          <h3 className="text-slate-900 font-bold text-xl mb-3" style={{fontFamily:'Montserrat'}}>More Civil</h3>
+          <h3 className="text-slate-900 font-bold text-xl mb-3">More Civil</h3>
           <p className="text-slate-600">Water cart delivery and civil earthworks across South Australia.</p>
         </div>
         <div>
-          <h3 className="text-slate-900 font-bold text-xl mb-3" style={{fontFamily:'Montserrat'}}>Contact</h3>
+          <h3 className="text-slate-900 font-bold text-xl mb-3">Contact</h3>
           <p className="text-slate-600">
             Phone: <a href="tel:0000000000" className="hover:text-[#00B4D8] transition-colors">0000 000 000</a><br/>
             Email: <a href="mailto:info@morecivil.com.au" className="hover:text-[#00B4D8] transition-colors">info@morecivil.com.au</a>
           </p>
         </div>
         <div>
-          <h3 className="text-slate-900 font-bold text-xl mb-3" style={{fontFamily:'Montserrat'}}>Links</h3>
+          <h3 className="text-slate-900 font-bold text-xl mb-3">Links</h3>
           <ul className="space-y-2 text-slate-600">
             <li><a href="#services" className="hover:text-[#00B4D8] transition-colors">Services</a></li>
             <li><a href="#projects" className="hover:text-[#00B4D8] transition-colors">Projects</a></li>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -11,7 +11,7 @@ export default function Gallery() {
   return (
     <section id="projects" className="py-32 bg-white">
       <div className="max-w-7xl mx-auto px-10">
-        <h2 className="reveal font-extrabold text-3xl mb-8 text-center" style={{fontFamily:'Montserrat'}}>Recent projects</h2>
+        <h2 className="reveal font-extrabold text-3xl mb-8 text-center">Recent projects</h2>
       </div>
     </section>
   );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,9 +2,7 @@ export default function Hero() {
   return <section id="home" className="relative bg-white text-slate-900 overflow-hidden pt-40">
       <div className="max-w-7xl mx-auto grid md:grid-cols-2 gap-20 items-center px-10 py-32">
         <div className="reveal">
-          <h1 className="font-extrabold leading-tight text-4xl md:text-5xl lg:text-6xl" style={{
-          fontFamily: 'Montserrat'
-        }}>
+          <h1 className="font-extrabold leading-tight text-4xl md:text-5xl lg:text-6xl">
             Water when you need it.<br /> Civil works you can trust.
           </h1>
           <p className="text-slate-600 mt-4 text-lg">

--- a/src/components/Quote.tsx
+++ b/src/components/Quote.tsx
@@ -3,7 +3,7 @@ export default function Quote() {
     <section id="quote" className="py-32 bg-white">
       <div className="max-w-7xl mx-auto px-10 grid md:grid-cols-2 gap-8">
         <div className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-10">
-          <h2 className="font-extrabold text-2xl mb-4" style={{fontFamily:'Montserrat'}}>Request a Quote</h2>
+          <h2 className="font-extrabold text-2xl mb-4">Request a Quote</h2>
           <form onSubmit={(e)=>{e.preventDefault(); alert('Demo — wire to email/form service in production');}} className="space-y-8">
             <input required placeholder="Full Name" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
             <input required type="email" placeholder="Email" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
@@ -23,7 +23,7 @@ export default function Quote() {
         </div>
 
         <div className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-10" id="contact">
-          <h2 className="font-extrabold text-2xl mb-4" style={{fontFamily:'Montserrat'}}>Book Water</h2>
+          <h2 className="font-extrabold text-2xl mb-4">Book Water</h2>
           <form onSubmit={(e)=>{e.preventDefault(); alert('Demo — wire to email/form service in production');}} className="space-y-8">
             <input required placeholder="Name" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>
             <input required placeholder="Phone" className="w-full p-3 border border-slate-300 rounded-lg focus:border-[#00B4D8] focus:outline-none focus:ring-1 focus:ring-[#00B4D8]"/>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,7 +1,7 @@
 const Card = ({badge, title, children}:{badge:string; title:string; children:React.ReactNode}) => (
   <div className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-10">
     <span className="inline-block bg-[#e0f7ff] text-[#043b4a] px-3 py-1 rounded-full font-bold text-sm mb-3">{badge}</span>
-    <h3 className="font-bold text-lg mb-3" style={{fontFamily:'Montserrat'}}>{title}</h3>
+    <h3 className="font-bold text-lg mb-3">{title}</h3>
     <div className="[&>ul]:list-disc [&>ul]:pl-5 [&>p]:text-slate-700 [&>ul]:text-slate-700">{children}</div>
   </div>
 );
@@ -10,7 +10,7 @@ export default function Services() {
   return (
     <section id="services" className="py-32 bg-white">
       <div className="max-w-7xl mx-auto px-10">
-        <h2 className="reveal font-extrabold text-3xl mb-8 text-center" style={{fontFamily:'Montserrat'}}>What we do</h2>
+        <h2 className="reveal font-extrabold text-3xl mb-8 text-center">What we do</h2>
         <div className="grid md:grid-cols-3 gap-12">
           <Card badge="Water Delivery" title="Potable & non-potable">
             <p>Bulk deliveries for tanks, pools, events, civil & roadworks.</p>

--- a/src/index.css
+++ b/src/index.css
@@ -115,13 +115,13 @@ All colors MUST be HSL.
 
   body {
     @apply bg-background text-foreground;
-    font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+    font-family: 'Montserrat', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
     line-height: 1.6;
     margin: 0;
   }
 
   h1, h2, h3, h4, h5, h6 {
-    font-family: 'Montserrat', 'Inter', Arial, sans-serif;
+    font-family: 'Montserrat', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
     margin: 0 0 0.6rem;
   }
 


### PR DESCRIPTION
## Summary
- Align site typography with logo by loading Montserrat weights only
- Apply Montserrat as global body and heading font and drop Inter
- Remove component-level font-family overrides and update docs

## Testing
- `npm run lint`
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_b_68b0ea543770832a8cc53f0e78a6eec3