### PR TITLE
Add placeholder reviews section to home page

### DIFF
--- a/src/components/Reviews.tsx
+++ b/src/components/Reviews.tsx
@@ -1,0 +1,26 @@
+// TODO: Replace placeholder reviews with actual content.
+const reviews = [
+  { author: 'Reviewer 1', text: 'Placeholder review text.' },
+  { author: 'Reviewer 2', text: 'Placeholder review text.' },
+  { author: 'Reviewer 3', text: 'Placeholder review text.' },
+  { author: 'Reviewer 4', text: 'Placeholder review text.' },
+  { author: 'Reviewer 5', text: 'Placeholder review text.' },
+];
+
+export default function Reviews() {
+  return (
+    <section id="reviews" className="py-32 bg-white">
+      <div className="max-w-7xl mx-auto px-10">
+        <h2 className="reveal font-extrabold text-3xl mb-8 text-center" style={{fontFamily:'Montserrat'}}>What our customers say</h2>
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {reviews.map((review, i) => (
+            <div key={i} className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-8">
+              <p className="italic mb-4 text-slate-700">"{review.text}"</p>
+              <p className="font-bold text-slate-900">{review.author}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import Services from "@/components/Services";
 import Gallery from "@/components/Gallery";
+import Reviews from "@/components/Reviews";
 import FAQ from "@/components/FAQ";
 import Quote from "@/components/Quote";
 import Footer from "@/components/Footer";
@@ -20,12 +21,13 @@ const Home = () => {
       <Hero />
       <Services />
       <Gallery />
+      <Reviews />
       <FAQ />
       <Quote />
       <Footer />
-      
+
       {/* Floating CTA */}
-      <button 
+      <button
         className="fixed right-6 bottom-6 z-50 bg-[#00B4D8] text-[#0B1F2A] font-extrabold px-4 py-3 rounded-xl shadow-lg hover:bg-[#00A3C4] transition-colors"
         onClick={() => document.querySelector('#quote')?.scrollIntoView({behavior:'smooth'})}
       >


### PR DESCRIPTION
## Summary
- add reviews section placeholder on the home page
- create reviews component with TODO for real Google reviews

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b0eb446890832aaac1d8f9925f3aef