### PR TITLE
feat: add blog page with inaugural post

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Projects from "./pages/Projects";
 import About from "./pages/About";
 import Contact from "./pages/Contact";
 import NotFound from "./pages/NotFound";
+import Blog from "./pages/Blog";
 
 const queryClient = new QueryClient();
 
@@ -26,6 +27,7 @@ const App = () => (
           <Route path="/projects" element={<Projects />} />
           <Route path="/about" element={<About />} />
           <Route path="/contact" element={<Contact />} />
+          <Route path="/blog" element={<Blog />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,6 +18,7 @@ export default function Footer() {
           <ul className="space-y-2 text-slate-600">
             <li><a href="#services" className="hover:text-[#00B4D8] transition-colors">Services</a></li>
             <li><a href="#projects" className="hover:text-[#00B4D8] transition-colors">Projects</a></li>
+            <li><a href="/blog" className="hover:text-[#00B4D8] transition-colors">Blog</a></li>
             <li><a href="#faq" className="hover:text-[#00B4D8] transition-colors">FAQ</a></li>
             <li><a href="#quote" className="hover:text-[#00B4D8] transition-colors">Quote</a></li>
             <li><a href="#contact" className="hover:text-[#00B4D8] transition-colors">Contact</a></li>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,7 @@ export default function Header() {
         <nav className="hidden md:flex items-center gap-6 text-black font-semibold">
           <a href="#services" className="text-black hover:text-[#00B4D8] transition-colors">Services</a>
           <a href="#projects" className="text-black hover:text-[#00B4D8] transition-colors">Projects</a>
+          <a href="/blog" className="text-black hover:text-[#00B4D8] transition-colors">Blog</a>
           <a href="#faq" className="text-black hover:text-[#00B4D8] transition-colors">FAQ</a>
           <a href="#quote" className="text-black hover:text-[#00B4D8] transition-colors">Quote</a>
           <a href="#contact" className="bg-gradient-to-r from-[#00B4D8] to-white text-black font-semibold px-6 py-3 rounded-xl shadow-lg hover:from-[#00A3C4] hover:to-white transition-all duration-300 border-2 border-[#0B1F2A]">Contact</a>
@@ -31,6 +32,7 @@ export default function Header() {
       {open && <div className="md:hidden px-6 pb-4 text-gray-900 space-y-2 bg-white border-t border-gray-200">
           <a onClick={() => setOpen(false)} href="#services" className="block py-2 hover:text-[#00B4D8]">Services</a>
           <a onClick={() => setOpen(false)} href="#projects" className="block py-2 hover:text-[#00B4D8]">Projects</a>
+          <a onClick={() => setOpen(false)} href="/blog" className="block py-2 hover:text-[#00B4D8]">Blog</a>
           <a onClick={() => setOpen(false)} href="#faq" className="block py-2 hover:text-[#00B4D8]">FAQ</a>
           <a onClick={() => setOpen(false)} href="#quote" className="block py-2 hover:text-[#00B4D8]">Quote</a>
           <a onClick={() => setOpen(false)} href="#contact" className="block py-2 hover:text-[#00B4D8]">Contact</a>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,0 +1,76 @@
+import { useEffect } from "react";
+import Layout from "@/components/Layout";
+import Footer from "@/components/Footer";
+
+const Blog = () => {
+  useEffect(() => {
+    document.title = "Blog – More Civil | Earthmoving News and Updates";
+    const meta = document.createElement("meta");
+    meta.name = "description";
+    meta.content = "Read the latest updates, insights, and project highlights from More Civil, a leading earthmoving equipment hire company in South Australia.";
+    document.head.appendChild(meta);
+    return () => {
+      document.head.removeChild(meta);
+    };
+  }, []);
+
+  return (
+    <Layout>
+      <section className="section">
+        <div className="container">
+          <h1>More Civil Blog</h1>
+          <p className="text-lg text-muted-foreground mb-12">Insights and updates from More Civil</p>
+
+          <article className="space-y-4 max-w-3xl mx-auto">
+            <h2>Building with Confidence: Insights from More Civil’s Director</h2>
+            <p className="text-sm text-muted-foreground italic">
+              By Shaun Reid, Director of More Civil – May 16, 2024
+            </p>
+            <p>
+              Welcome to the first post on the More Civil blog. I’m Shaun Reid, and after more than three decades in
+              South Australia’s earthmoving and construction scene, I’m proud to share our story and the knowledge
+              we’ve gained along the way. Since founding More Civil in 2018, our goal has been simple: provide reliable
+              earthmoving equipment hire and experienced operators who treat every project as if it were their own.
+            </p>
+            <p>
+              Over the past few years we have rapidly grown into a trusted name for machinery hire across Adelaide and
+              regional communities. Clients tell us they value our attention to safety, our transparent communication,
+              and the way we deliver results without surprises. One recent review summed it up perfectly: our team
+              “went above and beyond to ensure the project ran smoothly,” and that is exactly the standard we aim for
+              every day.
+            </p>
+            <h3>Our Mission</h3>
+            <p>
+              The civil construction industry is always evolving, and with over 30 years of hands-on experience I’ve
+              learned the importance of staying adaptable while never compromising on quality. More Civil has been
+              proudly serving South Australia since 2018, and we’re committed to combining modern equipment with old-
+              fashioned service. Whether it’s a small residential excavation or a large infrastructure project, our
+              focus remains on safety, reliability and customer satisfaction.
+            </p>
+            <h3>What to Expect from This Blog</h3>
+            <p>
+              This space will feature practical tips for planning construction projects, news about our latest work, and
+              insights into best practices for earthmoving and machinery hire in South Australia. We’ll highlight how
+              to get the most from equipment on site, explain regulatory updates, and showcase the projects that make
+              us proud to be part of the local industry. My hope is that these articles will help builders, developers,
+              and property owners make informed decisions when it comes to earthworks and water services.
+            </p>
+            <p>
+              Thank you for taking the time to read our inaugural post. I’m excited to share more stories and expertise
+              in the months ahead. If there’s a topic you’d like us to cover or a question about our services, please
+              don’t hesitate to <a href="/contact" className="underline hover:text-[#00B4D8]">get in touch</a>. Stay
+              tuned for more updates from the team at More Civil.
+            </p>
+          </article>
+        </div>
+      </section>
+      <Footer />
+      <style>{`
+        .container { max-width: 1200px; margin: 0 auto; padding: 0 1.25rem; }
+        .section { padding: 4rem 0; }
+      `}</style>
+    </Layout>
+  );
+};
+
+export default Blog;


### PR DESCRIPTION
## Summary
- add new /blog route and publish initial article from director Shaun Reid
- expose Blog link in header and footer navigation for easy access

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b407593d00832ab813dbe9d992d7e3