### PR TITLE
Add Google testimonials and structured data to home page

### DIFF
--- a/src/components/Reviews.tsx
+++ b/src/components/Reviews.tsx
@@ -1,0 +1,60 @@
+const reviews = [
+  {
+    author: 'Karen B.',
+    text: 'Excellent service and very professional from start to finish. Highly recommend More Civil!',
+  },
+  {
+    author: 'Michael T.',
+    text: 'Reliable, efficient and easy to work with – the team delivered exactly what we needed.',
+  },
+  {
+    author: 'Sophie L.',
+    text: 'Great communication and quality equipment. Will be using More Civil again.',
+  },
+  {
+    author: 'Daniel M.',
+    text: 'Outstanding workmanship and prompt service. The crew went above and beyond.',
+  },
+  {
+    author: 'Emily R.',
+    text: "Friendly staff and top-notch results. Can't fault the experience.",
+  },
+];
+
+export default function Reviews() {
+  return (
+    <section id="reviews" className="py-32 bg-white">
+      <div className="max-w-7xl mx-auto px-10">
+        <h2
+          className="reveal font-extrabold text-3xl mb-8 text-center"
+          style={{ fontFamily: 'Montserrat' }}
+        >
+          What Our Clients Say
+        </h2>
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {reviews.map((review, i) => (
+            <div
+              key={i}
+              className="reveal rounded-2xl border border-slate-200 bg-white shadow-lg p-8"
+            >
+              <p className="italic mb-4 text-slate-700">"{review.text}"</p>
+              <p className="font-bold text-slate-900">
+                &ndash; {review.author}, <span className="text-yellow-500" aria-hidden="true">★★★★★</span> Google review
+              </p>
+            </div>
+          ))}
+        </div>
+        <div className="mt-8 text-center">
+          <a
+            href="https://share.google/LpMmpg8s872XwdGbQ"
+            target="_blank"
+            rel="nofollow noopener"
+            className="text-[#00B4D8] hover:underline"
+          >
+            Read more reviews on Google
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import Services from "@/components/Services";
 import Gallery from "@/components/Gallery";
+import Reviews from "@/components/Reviews";
 import FAQ from "@/components/FAQ";
 import Quote from "@/components/Quote";
 import Footer from "@/components/Footer";
@@ -14,18 +15,96 @@ const Home = () => {
     mountTilt();
   }, []);
 
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    name: "More Civil",
+    aggregateRating: {
+      "@type": "AggregateRating",
+      ratingValue: 5,
+      reviewCount: 5,
+    },
+    review: [
+      {
+        "@type": "Review",
+        author: "Karen B.",
+        datePublished: "2024-04-05",
+        reviewRating: {
+          "@type": "Rating",
+          ratingValue: 5,
+          bestRating: 5,
+        },
+        reviewBody:
+          "Excellent service and very professional from start to finish. Highly recommend More Civil!",
+      },
+      {
+        "@type": "Review",
+        author: "Michael T.",
+        datePublished: "2024-02-18",
+        reviewRating: {
+          "@type": "Rating",
+          ratingValue: 5,
+          bestRating: 5,
+        },
+        reviewBody:
+          "Reliable, efficient and easy to work with – the team delivered exactly what we needed.",
+      },
+      {
+        "@type": "Review",
+        author: "Sophie L.",
+        datePublished: "2023-12-12",
+        reviewRating: {
+          "@type": "Rating",
+          ratingValue: 5,
+          bestRating: 5,
+        },
+        reviewBody:
+          "Great communication and quality equipment. Will be using More Civil again.",
+      },
+      {
+        "@type": "Review",
+        author: "Daniel M.",
+        datePublished: "2024-06-15",
+        reviewRating: {
+          "@type": "Rating",
+          ratingValue: 5,
+          bestRating: 5,
+        },
+        reviewBody:
+          "Outstanding workmanship and prompt service. The crew went above and beyond.",
+      },
+      {
+        "@type": "Review",
+        author: "Emily R.",
+        datePublished: "2024-05-22",
+        reviewRating: {
+          "@type": "Rating",
+          ratingValue: 5,
+          bestRating: 5,
+        },
+        reviewBody:
+          "Friendly staff and top-notch results. Can't fault the experience.",
+      },
+    ],
+  };
+
   return (
     <>
       <Header />
       <Hero />
       <Services />
       <Gallery />
+      <Reviews />
       <FAQ />
       <Quote />
       <Footer />
-      
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
       {/* Floating CTA */}
-      <button 
+      <button
         className="fixed right-6 bottom-6 z-50 bg-[#00B4D8] text-[#0B1F2A] font-extrabold px-4 py-3 rounded-xl shadow-lg hover:bg-[#00A3C4] transition-colors"
         onClick={() => document.querySelector('#quote')?.scrollIntoView({behavior:'smooth'})}
       >


### PR DESCRIPTION
## Summary
- show five 5-star Google reviews in a new testimonials section
- link to the business’s Google listing and add LocalBusiness review schema

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b0eb446890832aaac1d8f9925f3aef