### PR TITLE
Optimize image loading and reduce initial JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,13 @@
     <meta name="description" content="Adelaide water cartage, dust suppression, tank fills and civil works across South Australia." />
     <meta name="author" content="MORECIVIL" />
     <link rel="canonical" href="https://www.morecivil.au/" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preload" href="/more-civil-hero-image.svg" as="image" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=Montserrat:wght@700;800;900&display=swap" rel="stylesheet">
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=Montserrat:wght@700;800;900&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preload" href="/more-civil-hero-image.svg" as="image" fetchpriority="high" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=Montserrat:wght@700;800;900&display=swap"
+      rel="stylesheet"
+    />
 
     <meta property="og:title" content="MORECIVIL" />
     <meta property="og:description" content="Water delivery, dust suppression, tank fills and civil works in Adelaide." />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,14 @@ export default function Header() {
   return <header className={`fixed top-0 w-full z-50 transition-all ${scrolled ? 'bg-white/20 shadow-lg' : 'bg-transparent'} backdrop-blur-sm`}>
       <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-3">
         <a href="#home" className="flex items-center gap-3 mx-[12px] py-0 my-0 px-[30px]">
-          <img src="/more-civil-transparent-logo.svg" alt="More Civil" className="h-30 w-auto -ml-14 bg-transparent" />
+          <img
+            src="/more-civil-transparent-logo.svg"
+            alt="More Civil"
+            className="h-30 w-auto -ml-14 bg-transparent"
+            width="454"
+            height="170"
+            decoding="async"
+          />
           
         </a>
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,7 +2,16 @@ export default function Hero() {
   return <section id="home" className="relative bg-white text-slate-900 overflow-hidden pt-20">
       {/* Hero Image directly under header with light blue background */}
       <div className="w-full bg-gradient-to-r from-[#00B4D8] to-white">
-        <img src="/more-civil-hero-image.svg" alt="More Civil hero image" className="w-full h-auto" />
+        <img
+          src="/more-civil-hero-image.svg"
+          alt="More Civil hero image"
+          className="w-full h-auto"
+          width="454"
+          height="170"
+          loading="eager"
+          fetchPriority="high"
+          decoding="async"
+        />
       </div>
       
       {/* Text content below image, full width */}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -151,10 +151,14 @@ const About = () => {
       <section className="section alt">
         <div className="container text-center">
           <h2 className="mb-8">Certifications & Accreditations</h2>
-          <img 
-            src={accreditations} 
-            alt="MORECIVIL accreditations - South Australia, AWA, Department for Environment and Water" 
+          <img
+            src={accreditations}
+            alt="MORECIVIL accreditations - South Australia, AWA, Department for Environment and Water"
             className="mx-auto max-w-full h-auto opacity-80 mb-8"
+            width="800"
+            height="512"
+            loading="lazy"
+            decoding="async"
           />
           <div className="grid grid-2">
             <div className="cert-list">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,32 +1,47 @@
-import { useEffect } from 'react';
+import { useEffect, lazy, Suspense } from "react";
 import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import Services from "@/components/Services";
-import Gallery from "@/components/Gallery";
-import FAQ from "@/components/FAQ";
-import Quote from "@/components/Quote";
-import Footer from "@/components/Footer";
+const Gallery = lazy(() => import("@/components/Gallery"));
+const FAQ = lazy(() => import("@/components/FAQ"));
+const Quote = lazy(() => import("@/components/Quote"));
+const Footer = lazy(() => import("@/components/Footer"));
 import { mountReveal, mountTilt } from "@/lib/motion";
 const Home = () => {
   useEffect(() => {
     mountReveal();
     mountTilt();
   }, []);
-  return <>
+  return (
+    <>
       <Header />
       <Hero />
       <Services />
-      <Gallery />
-      <FAQ />
-      <Quote />
-      <Footer />
-      
+      <Suspense fallback={null}>
+        <Gallery />
+      </Suspense>
+      <Suspense fallback={null}>
+        <FAQ />
+      </Suspense>
+      <Suspense fallback={null}>
+        <Quote />
+      </Suspense>
+      <Suspense fallback={null}>
+        <Footer />
+      </Suspense>
+
       {/* Floating CTA */}
-      <button onClick={() => document.querySelector('#quote')?.scrollIntoView({
-      behavior: 'smooth'
-    })} className="fixed right-6 bottom-6 z-50 bg-gradient-to-r from-[#00B4D8] to-white text-[#0B1F2A] font-semibold rounded-xl shadow-lg hover:from-[#00A3C4] hover:to-white transition-all duration-300 border-2 border-[#0B1F2A] mx-0 px-0 my-[31px] py-[6px]">
+      <button
+        onClick={() =>
+          document
+            .querySelector("#quote")
+            ?.scrollIntoView({ behavior: "smooth" })
+        }
+        className="fixed right-6 bottom-6 z-50 bg-gradient-to-r from-[#00B4D8] to-white text-[#0B1F2A] font-semibold rounded-xl shadow-lg hover:from-[#00A3C4] hover:to-white transition-all duration-300 border-2 border-[#0B1F2A] mx-0 px-0 my-[31px] py-[6px]"
+      >
         Request a Quote
       </button>
-    </>;
+    </>
+  );
 };
 export default Home;

--- a/src/pages/Water.tsx
+++ b/src/pages/Water.tsx
@@ -25,7 +25,14 @@ const Water = () => {
             </div>
             
             <div className="media">
-              <img src="/water-truck.png" alt="MORECIVIL water delivery truck" className="max-w-full h-auto reveal tilt float" />
+              <img
+                src="/water-truck.png"
+                alt="MORECIVIL water delivery truck"
+                className="max-w-full h-auto reveal tilt float"
+                width="800"
+                height="600"
+                decoding="async"
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Prioritize hero image and remove duplicate font links to shorten render blocking time
- Add explicit dimensions and async decoding for multiple images to avoid layout shifts
- Lazy-load noncritical components to cut initial JavaScript

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68b56b51b4b8832aa824a0987317bd33